### PR TITLE
Fix bug where user input was being passed to calculations as strings.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "pension-calculator",
   "version": "0.0.1",
   "devDependencies": {
-    "angular": "~1.2",
+    "angular": "~1.3",
     "angular-mocks": "~1.2",
     "bootstrap": "~3.1",
     "angular-bootstrap": "~0.10.0",
@@ -11,5 +11,8 @@
     "font-awesome": "4.3.0",
     "animate.css": "3.2.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "resolutions": {
+    "angular": "~1.3"
+  }
 }

--- a/src/common/calc/CalcDirective.js
+++ b/src/common/calc/CalcDirective.js
@@ -31,6 +31,22 @@
         ];
         scope.modeSelected = scope.modes[0];
 
+        scope.spouseAge = 3;
+        scope.ageAtHire = 25;
+        scope.ageAtRetire = 55;
+        scope.wageAtHire = 20000;
+        scope.wageAtRetire = 62374;
+        scope.finalSalaryYears = 3;
+        scope.interestRate = 4;
+        scope.investReturn = 6;
+        scope.definedContributionPercent = null;
+        scope.definedBenefitPercent = null;
+
+        // The client uses a getter/setter to access these because Angular 1.3 treats the HTML input type "range" as a string.
+        // https://github.com/angular/angular.js/pull/9715
+        scope._COLAAdjustment = 2;
+        scope._survivor = 0;
+
         var computeDivSizes = function(animate) {
           var calcPanel = jQuery('.calc');
           var inputPanel = jQuery('.input-panel');
@@ -119,22 +135,22 @@
         scope.isInputsValid = function() {
 
           if (scope.modeSelected.key === 'dc') {
-            if (scope.inputData.definedBenefitPercent != null && !isNaN(scope.inputData.definedBenefitPercent)) {
+            if (scope.definedBenefitPercent != null && !isNaN(scope.definedBenefitPercent)) {
               if (scope.showInputChangedByUser === false) {
                 delayedShowInput();
               }
               return true;
             }
           } else if (scope.modeSelected.key === 'db') {
-            if (scope.inputData.definedContributionPercent != null && !isNaN(scope.inputData.definedContributionPercent)) {
+            if (scope.definedContributionPercent != null && !isNaN(scope.definedContributionPercent)) {
               if (scope.showInputChangedByUser === false) {
                 delayedShowInput();
               }
               return true;
             }
           } else if (scope.modeSelected.key === 'reduction') {
-            if (scope.inputData.definedBenefitPercent != null &&
-                scope.inputData.definedContributionPercent != null && !isNaN(scope.inputData.definedBenefitPercent) && !isNaN(scope.inputData.definedContributionPercent)) {
+            if (scope.definedBenefitPercent != null &&
+                scope.definedContributionPercent != null && !isNaN(scope.definedBenefitPercent) && !isNaN(scope.definedContributionPercent)) {
               if (scope.showInputChangedByUser === false) {
                 delayedShowInput();
               }
@@ -146,29 +162,34 @@
         };
 
         scope.updateWageIncrease = function() {
-          scope.wageIncrease = Math.pow(scope.inputData.wageAtRetire / scope.inputData.wageAtHire, 1 / (scope.inputData.ageAtRetire - scope.inputData.ageAtHire - 1)) - 1;
+          scope.wageIncrease = Math.pow(scope.wageAtRetire / scope.wageAtHire, 1 / (scope.ageAtRetire - scope.ageAtHire - 1)) - 1;
         };
-        // Deep watch of input data object.
-        scope.$watch('inputData', function(newValue, oldValue) {
+
+        // Watch of calculation parameters.
+        scope.$watchGroup(['_survivor', 'spouseAge', 'ageAtHire', 'ageAtRetire', 'wageAtHire', 'wageAtRetire',
+          'finalSalaryYears', 'investRate', 'investReturn', '_COLAAdjustment', 'definedContributionPercent',
+          'definedBenefitPercent'], function(newValues, oldValues) {
           scope.updateWageIncrease();
           scope.calculateOutput();
         }, true);
 
-
-        scope.inputData = {
-          survivor: 0,
-          spouseAge: 3,
-          COLAAdjustment: 2,
-          ageAtHire: 25,
-          ageAtRetire: 55,
-          wageAtHire: 20000,
-          wageAtRetire: 62374,
-          finalSalaryYears: 3,
-          interestRate: 4,
-          investReturn: 6
+        // A getter/setter to access COLAAdjustment because Angular 1.3 treats the HTML input type "range" as a string.
+        scope.COLAAdjustment = function(value) {
+          if (typeof(value) !== 'undefined') {
+            scope._COLAAdjustment = parseInt(value, 10);
+          }
+          return scope._COLAAdjustment.toString();
         };
 
-        scope.inputData.sex = scope.sexOptions[0];
+        // A getter/setter to access survivor because Angular 1.3 treats the HTML input type "range" as a string.
+        scope.survivor = function(value) {
+          if (typeof(value) !== 'undefined') {
+            scope._survivor = parseInt(value, 10);
+          }
+          return scope._survivor.toString();
+        };
+
+        scope.sex = scope.sexOptions[0];
 
         scope.xValue = 0;
         scope.yValue = 0;
@@ -602,27 +623,27 @@
         ];
 
         scope.calculateOutput = function() {
-          console.log('----- yoyo: ', scope.inputData.ageAtHire, scope.inputData.ageAtRetire, scope.inputData.wageAtHire, scope.xValue);
+          console.log('----- yoyo: ', scope.ageAtHire, scope.ageAtRetire, scope.wageAtHire, scope.xValue);
           if (scope.modeSelected.key == 'dc' || scope.modeSelected.key == 'reduction') {
-            scope.xValue = calcService.ComputeXValue(scope.inputData.ageAtHire, scope.inputData.ageAtRetire, scope.inputData.wageAtHire, scope.inputData.definedBenefitPercent, scope.inputData.investReturn, scope.wageIncrease);
-            scope.yValue = calcService.ComputeYValue(scope.inputData.ageAtHire, scope.inputData.ageAtRetire, scope.inputData.wageAtHire, scope.inputData.definedBenefitPercent, scope.inputData.investReturn);
-            scope.zValue = calcService.ComputeZValue([scope.inputData.interestRate], 'spot', 'ownstatic', scope.table, 0, 55, 55, scope.inputData.sex, 0, 0, 52, 1, 1, 0, scope.inputData.COLAAdjustment, scope.inputData.ageAtRetire);
-            scope.lifeOnly = calcService.ComputeFinalValue(scope.inputData.wageAtRetire, scope.inputData.finalSalaryYears, scope.wageIncrease, scope.xValue, scope.yValue, scope.zValue);
+            scope.xValue = calcService.ComputeXValue(scope.ageAtHire, scope.ageAtRetire, scope.wageAtHire, scope.definedBenefitPercent, scope.investReturn, scope.wageIncrease);
+            scope.yValue = calcService.ComputeYValue(scope.ageAtHire, scope.ageAtRetire, scope.wageAtHire, scope.definedBenefitPercent, scope.investReturn);
+            scope.zValue = calcService.ComputeZValue([scope.interestRate], 'spot', 'ownstatic', scope.table, 0, 55, 55, scope.sex, 0, 0, 52, 1, 1, 0, scope._COLAAdjustment, scope.ageAtRetire);
+            scope.lifeOnly = calcService.ComputeFinalValue(scope.wageAtRetire, scope.finalSalaryYears, scope.wageIncrease, scope.xValue, scope.yValue, scope.zValue);
 
-            scope.zValue = calcService.ComputeZValue([scope.inputData.interestRate], 'spot', 'ownstatic', scope.table, 0, 55, 55, scope.inputData.sex, 0, 0, 52, 1, 1, scope.inputData.survivor, scope.inputData.COLAAdjustment, scope.inputData.ageAtRetire);
-            scope.jointOutput = calcService.ComputeFinalValue(scope.inputData.wageAtRetire, scope.inputData.finalSalaryYears, scope.wageIncrease, scope.xValue, scope.yValue, scope.zValue);
+            scope.zValue = calcService.ComputeZValue([scope.interestRate], 'spot', 'ownstatic', scope.table, 0, 55, 55, scope.sex, 0, 0, 52, 1, 1, scope._survivor, scope._COLAAdjustment, scope.ageAtRetire);
+            scope.jointOutput = calcService.ComputeFinalValue(scope.wageAtRetire, scope.finalSalaryYears, scope.wageIncrease, scope.xValue, scope.yValue, scope.zValue);
           }
 
           if (scope.modeSelected.key == 'db' || scope.modeSelected.key == 'reduction') {
-            var adjustedTotalWages = calcService.GenerateTotalWages(scope.inputData.sex, scope.inputData.COLAAdjustment, scope.inputData.ageAtRetire, scope.inputData.spouseAge, scope.inputData.wageAtRetire, scope.inputData.finalSalaryYears, scope.inputData.definedContributionPercent, scope.wageIncrease, scope.inputData.interestRate, 0);
-            var adjustedTotalWagesJoint = calcService.GenerateTotalWages(scope.inputData.sex, scope.inputData.COLAAdjustment, scope.inputData.ageAtRetire, scope.inputData.spouseAge, scope.inputData.wageAtRetire, scope.inputData.finalSalaryYears, scope.inputData.definedContributionPercent, scope.wageIncrease, scope.inputData.interestRate, scope.inputData.survivor);
-            scope.dbLifeOnly = calcService.ComputeEmployeeContrib(scope.inputData.ageAtHire, scope.inputData.ageAtRetire, scope.inputData.wageAtHire, scope.inputData.investReturn, scope.wageIncrease, adjustedTotalWages);
-            scope.dbJointOutput = calcService.ComputeEmployeeContrib(scope.inputData.ageAtHire, scope.inputData.ageAtRetire, scope.inputData.wageAtHire, scope.inputData.investReturn, scope.wageIncrease, adjustedTotalWagesJoint);
+            var adjustedTotalWages = calcService.GenerateTotalWages(scope.sex, scope._COLAAdjustment, scope.ageAtRetire, scope.spouseAge, scope.wageAtRetire, scope.finalSalaryYears, scope.definedContributionPercent, scope.wageIncrease, scope.interestRate, 0);
+            var adjustedTotalWagesJoint = calcService.GenerateTotalWages(scope.sex, scope._COLAAdjustment, scope.ageAtRetire, scope.spouseAge, scope.wageAtRetire, scope.finalSalaryYears, scope.definedContributionPercent, scope.wageIncrease, scope.interestRate, scope._survivor);
+            scope.dbLifeOnly = calcService.ComputeEmployeeContrib(scope.ageAtHire, scope.ageAtRetire, scope.wageAtHire, scope.investReturn, scope.wageIncrease, adjustedTotalWages);
+            scope.dbJointOutput = calcService.ComputeEmployeeContrib(scope.ageAtHire, scope.ageAtRetire, scope.wageAtHire, scope.investReturn, scope.wageIncrease, adjustedTotalWagesJoint);
           }
 
           if (scope.modeSelected.key == 'reduction') {
-            scope.reductionOutput = scope.lifeOnly - scope.inputData.definedContributionPercent;
-            scope.reductionJointOutput = scope.jointOutput - scope.inputData.definedContributionPercent;
+            scope.reductionOutput = scope.lifeOnly - scope.definedContributionPercent;
+            scope.reductionJointOutput = scope.jointOutput - scope.definedContributionPercent;
             if (scope.reductionOutput > 0.0) {
               scope.barStyle = { 'width': scope.reductionOutput + '%', 'background-color': 'green'};
             } else {

--- a/src/common/calc/partial/calc.tpl.html
+++ b/src/common/calc/partial/calc.tpl.html
@@ -5,14 +5,14 @@
             <select class="animated fadeIn form-control field" id="calcMode" ng-model="modeSelected" ng-options="mode.value for mode in modes" required=""></select>
             <div class="animated fadeInUp" ng-show="modeSelected.key == 'db' || modeSelected.key =='reduction'">
                 <div class="field-label">Specify Retirement Pension as % of Final Salary(s)</div>
-                <input id="defined-contribution" ng-model="inputData.definedContributionPercent" class="form-control field">
+                <input id="defined-contribution" ng-model="definedContributionPercent" class="form-control field">
             </div>
             <div ng-show="modeSelected.key == 'dc' || modeSelected.key =='reduction'">
                 <div class=" animated fadeInUp">
                     <div class="field-label">Specify 401k Contribution as % of Payroll</div>
-                    <input id="defined-benefit"  ng-model="inputData.definedBenefitPercent" class="form-control field">
+                    <input id="defined-benefit"  ng-model="definedBenefitPercent" class="form-control field">
                     <!--
-                    <input class="field-slider" type="range" max="100" ng-model="inputData.definedBenefitPercent">
+                    <input class="field-slider" type="range" max="100" ng-model="definedBenefitPercent">
                     -->
                 </div>
             </div>
@@ -24,8 +24,8 @@
                             {{dbLifeOnly | number:2}}%
                         </div>
                     </div>
-                    <div class="field-label  animated fadeInDown" ng-show="inputData.survivor > 0">Required 401k Contribution w/ Survivor %</div>
-                    <div class="progress animated fadeInDown" ng-show="inputData.survivor > 0">
+                    <div class="field-label  animated fadeInDown" ng-show="_survivor > 0">Required 401k Contribution w/ Survivor %</div>
+                    <div class="progress animated fadeInDown" ng-show="_survivor > 0">
                         <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuemin="0" aria-valuemax="100" style="width: {{dbJointOutput}}%;">
                         {{dbJointOutput | number:2}}%
                         </div>
@@ -38,8 +38,8 @@
                         {{lifeOnly | number:2}}%
                         </div>
                     </div>
-                    <div class="field-label  animated fadeInDown" ng-show="inputData.survivor > 0">Pension Income Replacement w/ Survivor</div>
-                    <div class="progress animated fadeInDown" ng-show="inputData.survivor > 0">
+                    <div class="field-label  animated fadeInDown" ng-show="_survivor > 0">Pension Income Replacement w/ Survivor</div>
+                    <div class="progress animated fadeInDown" ng-show="_survivor > 0">
                         <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuemin="0" aria-valuemax="100" style="width: {{jointOutput}}%;">
                         {{jointOutput | number:2}}%
                         </div>
@@ -52,8 +52,8 @@
                             {{reductionOutput | absolute | number:2}}%
                         </div>
                     </div>
-                    <div class="field-label  animated fadeInDown" ng-show="inputData.survivor > 0">Difference 401k vs Pension w/ Survivor %</div>
-                    <div class="progress animated fadeInDown" ng-show="inputData.survivor > 0">
+                    <div class="field-label  animated fadeInDown" ng-show="_survivor > 0">Difference 401k vs Pension w/ Survivor %</div>
+                    <div class="progress animated fadeInDown" ng-show="_survivor > 0">
                         <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuemin="0" aria-valuemax="100" ng-style="jointStyle">
                         {{reductionJointOutput | absolute | number:2}}%
                         </div>
@@ -71,38 +71,38 @@
         <div id="input-panel-content" class="section">
             <div>
                 <div class="field-label">Age at Hire</div>
-                <input ng-model="inputData.ageAtHire" id="age-at-hire" class="form-control field" >
+                <input ng-model="ageAtHire" type="number" id="age-at-hire" class="form-control field" >
             </div>
             <div>
                 <div class="field-label">Age at Retirement</div>
-                <input ng-model="inputData.ageAtRetire" id="age-at-retirement" class="form-control field" >
+                <input ng-model="ageAtRetire" type="number" id="age-at-retirement" class="form-control field" >
             </div>
             <div>
                 <div class="field-label">Annual Wage at Hire</div>
-                <input ng-model="inputData.wageAtHire" id="annual-wage-at-hire" class="form-control field" >
+                <input ng-model="wageAtHire" type="number" id="annual-wage-at-hire" class="form-control field" >
             </div>
             <div>
                 <div class="field-label">Annual Wage at Retirement</div>
-                <input ng-model="inputData.wageAtRetire" id="annual-wage-at-retirement" class="form-control field" >
+                <input ng-model="wageAtRetire" type="number" id="annual-wage-at-retirement" class="form-control field" >
             </div>
 
             <div class="animated fadeInRight" ng-show="showAssumptions">
                 <div>
                     <div class="field-label">Years of Which Final Average Salary Based</div>
-                    <input ng-model="inputData.finalSalaryYears" id="years-of-which-final-average-salary-based" class="form-control field" >
+                    <input ng-model="finalSalaryYears" type="number" id="years-of-which-final-average-salary-based" class="form-control field" >
                 </div>
                 <div>
                     <div class="field-label">Retiree Cost of Living Adjustment (COLA) %</div>
-                    <input ng-model="inputData.COLAAdjustment" id="retiree-cost-of-living-adjustment" class="form-control field" >
-                    <input class="field-slider" type="range" max="100" ng-model="inputData.COLAAdjustment">
+                    <input ng-model="COLAAdjustment" id="retiree-cost-of-living-adjustment" class="form-control field" ng-model-options="{ getterSetter: true }">
+                    <input class="field-slider" type="range" max="100" ng-model="COLAAdjustment" ng-model-options="{ getterSetter: true }">
                 </div>
                 <div>
                     <div class="field-label">401k Investment Return %</div>
-                    <input id="401k-investment-return" class="form-control field" ng-model="inputData.investReturn">
+                    <input id="401k-investment-return" type="number" class="form-control field" ng-model="investReturn">
                 </div>
                 <div>
                     <div class="field-label">Annuity Interest Rate %</div>
-                    <input id="annuity-interest-rate" class="form-control field" ng-model="inputData.interestRate">
+                    <input id="annuity-interest-rate" type="number" class="form-control field" ng-model="interestRate">
                 </div>
                 <div>
                     <div class="field-label">Wage Increase %</div>
@@ -110,12 +110,12 @@
                 </div>
                 <div>
                     <div class="field-label">Survivor %</div>
-                    <input id="survivor-input-dc" class="form-control field" ng-model="inputData.survivor">
-                    <input id="survivor-slider-dc" class="field-slider" type="range" max="100" ng-model="inputData.survivor">
+                    <input id="survivor-input-dc" class="form-control field" ng-model="survivor" ng-model-options="{ getterSetter: true }">
+                    <input id="survivor-slider-dc" class="field-slider" type="range" max="100" ng-model="survivor" ng-model-options="{ getterSetter: true }">
                 </div>
                 <div>
                     <div class="field-label">Sex</div>
-                    <select class="animated fadeIn form-control field"  id="sex-selection" ng-model="inputData.sex" ng-options="sex for sex in sexOptions"></select>
+                    <select class="animated fadeIn form-control field"  id="sex-selection" ng-model="sex" ng-options="sex for sex in sexOptions"></select>
                 </div>
             </div>
             <div class="advanced-header no-select" ng-click="showAssumptions = !showAssumptions" tooltip="{{showAssumptions?'Show ':'Hide '}} assumptions.">


### PR DESCRIPTION
* Add 'type="number"' to the numeric input directives, with the exception of the range/input directives (survivor and cola).
* Remove the inputData object in the CalcDirective in favor of declaring variables directly on the scope.
* Bump angular to 1.3 to allow getters/setters on ng-model directives and use of the $watchGroup function.